### PR TITLE
Fix initialization without config

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,17 @@
+name: Test with pytest
+
+on: [push]
+
+jobs:
+  testing:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        pip install .
+        pip install pytest
+    - name: run test
+      run: pytest

--- a/knossos_utils/knossosdataset.py
+++ b/knossos_utils/knossosdataset.py
@@ -816,25 +816,22 @@ class KnossosDataset(object):
             np.array(self.boundary).astype(np.float) / self.cube_shape), dtype=np.int)
 
         if create_knossos_conf:
-            all_mag_folders = our_glob(path+"/*mag*")
-            for mag_folder in all_mag_folders:
-                this_mag = re.findall("[\d]+", mag_folder)[-1]
-                with open(mag_folder+"/knossos.conf", "w") as f:
-                    f.write('experiment name "%s_mag%s";\n' %(experiment_name,
-                                                              this_mag))
-                    f.write('boundary x %d;\n' % boundary[0])
-                    f.write('boundary y %d;\n' % boundary[1])
-                    f.write('boundary z %d;\n' % boundary[2])
-                    f.write('scale x %.2f;\n' % scale[0])
-                    f.write('scale y %.2f;\n' % scale[1])
-                    f.write('scale z %.2f;\n' % scale[2])
-                    f.write('magnification %s;' % this_mag)
+            self._conf_path = self.knossos_path + "/knossos.conf"
+            with open(self.conf_path, "w") as f:
+                f.write('experiment name "%s_mag%s";\n' %(experiment_name,
+                                                            sorted(mags)[0]))
+                f.write('boundary x %d;\n' % boundary[0])
+                f.write('boundary y %d;\n' % boundary[1])
+                f.write('boundary z %d;\n' % boundary[2])
+                f.write('scale x %.2f;\n' % scale[0])
+                f.write('scale y %.2f;\n' % scale[1])
+                f.write('scale z %.2f;\n' % scale[2])
+                f.write('magnification %s;' % sorted(mags)[0])
+
         if verbose:
-            print(sorted(Path(path).glob('*')))
             _print("Initialization finished successfully")
 
         self._initialize_cache(cache_size)
-        print(sorted(Path(path).glob('*')))
         self._initialized = True
 
     def initialize_from_matrix(self, path, scale, experiment_name,

--- a/knossos_utils/knossosdataset.py
+++ b/knossos_utils/knossosdataset.py
@@ -787,15 +787,15 @@ class KnossosDataset(object):
             for mag in mags:
                 exists = False
                 for mag_folder in all_mag_folders:
-                    if "mag"+str(mag) in mag_folder:
+                    if mag_folder.endswith(f'mag{mag}'):
                         exists = True
                         break
                 if not exists:
                     if len(all_mag_folders) > 0:
-                        os.makedirs(path+"/"+ re.findall('[a-zA-Z0-9,_ -]+',
-                                    all_mag_folders[0][:-1])[-1] + str(mag))
+                        assert(not re.match('.*mag\d+$', all_mag_folders[0]) is None)
+                        os.makedirs(re.sub('mag\d+$', f'mag{mag}', all_mag_folders[0]))
                     else:
-                            os.makedirs(path+"/mag"+str(mag))
+                        os.makedirs(path+"/mag"+str(mag))
         else:
             assert(len(all_mag_folders) > 0)
 
@@ -830,10 +830,11 @@ class KnossosDataset(object):
                     f.write('scale z %.2f;\n' % scale[2])
                     f.write('magnification %s;' % this_mag)
         if verbose:
+            print(sorted(Path(path).glob('*')))
             _print("Initialization finished successfully")
 
         self._initialize_cache(cache_size)
-
+        print(sorted(Path(path).glob('*')))
         self._initialized = True
 
     def initialize_from_matrix(self, path, scale, experiment_name,
@@ -2085,6 +2086,8 @@ class KnossosDataset(object):
             if kzip_path.endswith(".k.zip"):
                 kzip_path = kzip_path[:-6]
             os.makedirs(kzip_path, exist_ok=True)
+
+        print(self._conf_path)
 
         # obtain clock difference between write destination and process system for correct block file age determination
         with tempfile.NamedTemporaryFile(dir=kzip_path if kzip_path else os.path.dirname(self._conf_path)) as time_file:

--- a/knossos_utils/knossosdataset.py
+++ b/knossos_utils/knossosdataset.py
@@ -781,7 +781,7 @@ class KnossosDataset(object):
         """
 
         self._knossos_path = path
-        all_mag_folders = our_glob(path+"*mag*")
+        all_mag_folders = our_glob(path+"/*mag*")
 
         if not mags is None:
             if make_mag_folders:
@@ -798,7 +798,7 @@ class KnossosDataset(object):
                         else:
                             os.makedirs(path+"/mag"+str(mag))
 
-        mag_folder = our_glob(path+"*mag*")[0].split("/")
+        mag_folder = our_glob(path+"/*mag*")[0].split("/")
         if len(mag_folder[-1]) > 1:
             mag_folder = mag_folder[-1]
         else:
@@ -815,7 +815,7 @@ class KnossosDataset(object):
             self.boundary.astype(np.float) / self.cube_shape), dtype=np.int)
 
         if create_knossos_conf:
-            all_mag_folders = our_glob(path+"*mag*")
+            all_mag_folders = our_glob(path+"/*mag*")
             for mag_folder in all_mag_folders:
                 this_mag = re.findall("[\d]+", mag_folder)[-1]
                 with open(mag_folder+"/knossos.conf", "w") as f:

--- a/knossos_utils/knossosdataset.py
+++ b/knossos_utils/knossosdataset.py
@@ -812,7 +812,7 @@ class KnossosDataset(object):
         self._experiment_name = experiment_name
 
         self._number_of_cubes = np.array(np.ceil(
-            self.boundary.astype(np.float) / self.cube_shape), dtype=np.int)
+            np.array(self.boundary).astype(np.float) / self.cube_shape), dtype=np.int)
 
         if create_knossos_conf:
             all_mag_folders = our_glob(path+"/*mag*")

--- a/knossos_utils/knossosdataset.py
+++ b/knossos_utils/knossosdataset.py
@@ -783,19 +783,18 @@ class KnossosDataset(object):
         self._knossos_path = path
         all_mag_folders = our_glob(path+"/*mag*")
 
-        if not mags is None:
-            if make_mag_folders:
-                for mag in mags:
-                    exists = False
-                    for mag_folder in all_mag_folders:
-                        if "mag"+str(mag) in mag_folder:
-                            exists = True
-                            break
-                    if not exists:
-                        if len(all_mag_folders) > 0:
-                            os.makedirs(path+"/"+ re.findall('[a-zA-Z0-9,_ -]+',
-                                        all_mag_folders[0][:-1])[-1] + str(mag))
-                        else:
+        if not mags is None and make_mag_folders:
+            for mag in mags:
+                exists = False
+                for mag_folder in all_mag_folders:
+                    if "mag"+str(mag) in mag_folder:
+                        exists = True
+                        break
+                if not exists:
+                    if len(all_mag_folders) > 0:
+                        os.makedirs(path+"/"+ re.findall('[a-zA-Z0-9,_ -]+',
+                                    all_mag_folders[0][:-1])[-1] + str(mag))
+                    else:
                             os.makedirs(path+"/mag"+str(mag))
         else:
             assert(len(all_mag_folders) > 0)

--- a/knossos_utils/knossosdataset.py
+++ b/knossos_utils/knossosdataset.py
@@ -797,6 +797,8 @@ class KnossosDataset(object):
                                         all_mag_folders[0][:-1])[-1] + str(mag))
                         else:
                             os.makedirs(path+"/mag"+str(mag))
+        else:
+            assert(len(all_mag_folders) > 0)
 
         mag_folder = our_glob(path+"/*mag*")[0].split("/")
         if len(mag_folder[-1]) > 1:

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -26,3 +26,9 @@ def test_KnossosDataset_initialize_without_conf__conf_exist(tmp_path):
   kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 10), scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
   assert(Path(kd.conf_path).is_file())
 
+def test_Knossosdataset__initalize_without_conf__robust_magfolder_detection(tmp_path):
+  (tmp_path / 'test_mag16').mkdir()
+  kd = KnossosDataset()
+  kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 10), scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
+  assert((tmp_path / 'test_mag1').is_dir())
+

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -1,8 +1,12 @@
 from knossos_utils import KnossosDataset
 import pytest
 
-def test_KnossosDataset_initialize_without_conf(tmp_path):
+import numpy as np
+
+@pytest.mark.parametrize("boundary", [np.array([7,9,10]), (7,9,10), [7, 9, 10]])
+def test_KnossosDataset_initialize_without_conf(tmp_path, boundary):
   from knossos_utils import KnossosDataset
   import numpy as np
   kd = KnossosDataset()
-  kd.initialize_without_conf(str(tmp_path), boundary=np.array([7, 9, 10]), scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
+  kd.initialize_without_conf(str(tmp_path), boundary=boundary, scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
+

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -5,8 +5,6 @@ import numpy as np
 
 @pytest.mark.parametrize("boundary", [np.array([7,9,10]), (7,9,10), [7, 9, 10]])
 def test_KnossosDataset_initialize_without_conf(tmp_path, boundary):
-  from knossos_utils import KnossosDataset
-  import numpy as np
   kd = KnossosDataset()
   kd.initialize_without_conf(str(tmp_path), boundary=boundary, scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
 

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -1,7 +1,8 @@
 from knossos_utils import KnossosDataset
-  
+import pytest
+
 def test_KnossosDataset_initialize_without_conf(tmp_path):
   from knossos_utils import KnossosDataset
+  import numpy as np
   kd = KnossosDataset()
-  kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 10), scale=(1, 1, 1), experiment_name='test', verbose=True)
-  
+  kd.initialize_without_conf(str(tmp_path), boundary=np.array([7, 9, 10]), scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -1,0 +1,7 @@
+from knossos_utils import KnossosDataset
+  
+def test_KnossosDataset_initialize_without_conf(tmp_path):
+  from knossos_utils import KnossosDataset
+  kd = KnossosDataset()
+  kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 10), scale=(1, 1, 1), experiment_name='test', verbose=True)
+  

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -4,8 +4,12 @@ import pytest
 import numpy as np
 
 @pytest.mark.parametrize("boundary", [np.array([7,9,10]), (7,9,10), [7, 9, 10]])
-@pytest.mark.parametrize("mags", [None, [1]])
-def test_KnossosDataset_initialize_without_conf(tmp_path, boundary, mags):
+def test_KnossosDataset_initialize_without_conf(tmp_path, boundary):
   kd = KnossosDataset()
-  kd.initialize_without_conf(str(tmp_path), boundary=boundary, scale=(1, 1, 1), experiment_name='test', mags=mags, verbose=True)
+  kd.initialize_without_conf(str(tmp_path), boundary=boundary, scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
 
+
+def test_KnossosDataset_initialize_without_conf(tmp_path):
+  kd = KnossosDataset()
+  with pytest.raises(AssertionError):
+    kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 10), scale=(1, 1, 1), experiment_name='test', mags=None, verbose=True)

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -18,3 +18,11 @@ def test_KnossosDataset_initalize_without_conf__mags_1_make_mag_folder_False(tmp
   kd = KnossosDataset()
   with pytest.raises(AssertionError):
     kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 19), scale=(1, 1, 1), experiment_name='test', mags=[1], make_mag_folders=False, verbose=True)
+
+
+def test_KnossosDataset_initialize_without_conf__conf_exist(tmp_path):
+  from pathlib import Path
+  kd = KnossosDataset()
+  kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 10), scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
+  assert(Path(kd.conf_path).is_file())
+

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -26,9 +26,14 @@ def test_KnossosDataset_initialize_without_conf__conf_exist(tmp_path):
   kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 10), scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
   assert(Path(kd.conf_path).is_file())
 
-def test_Knossosdataset__initalize_without_conf__robust_magfolder_detection(tmp_path):
-  (tmp_path / 'test_mag16').mkdir()
+@pytest.mark.parametrize('existing_mag,expected_mag', [
+  ('test_mag16', 'test_mag1'),
+  ('test_mag1', 'test_mag1'),
+  ('mag16', 'mag1'),
+  ('mag1', 'mag1')])
+def test_Knossosdataset__initalize_without_conf__robust_magfolder_detection(tmp_path, existing_mag, expected_mag):
+  (tmp_path / existing_mag).mkdir()
   kd = KnossosDataset()
   kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 10), scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
-  assert((tmp_path / 'test_mag1').is_dir())
+  assert((tmp_path / expected_mag).is_dir())
 

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -4,12 +4,12 @@ import pytest
 import numpy as np
 
 @pytest.mark.parametrize("boundary", [np.array([7,9,10]), (7,9,10), [7, 9, 10]])
-def test_KnossosDataset_initialize_without_conf(tmp_path, boundary):
+def test_KnossosDataset_initialize_without_conf__boundary(tmp_path, boundary):
   kd = KnossosDataset()
   kd.initialize_without_conf(str(tmp_path), boundary=boundary, scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
 
 
-def test_KnossosDataset_initialize_without_conf(tmp_path):
+def test_KnossosDataset_initialize_without_conf__mags(tmp_path):
   kd = KnossosDataset()
   with pytest.raises(AssertionError):
     kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 10), scale=(1, 1, 1), experiment_name='test', mags=None, verbose=True)

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -13,3 +13,8 @@ def test_KnossosDataset_initialize_without_conf__mags(tmp_path):
   kd = KnossosDataset()
   with pytest.raises(AssertionError):
     kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 10), scale=(1, 1, 1), experiment_name='test', mags=None, verbose=True)
+
+def test_KnossosDataset_initalize_without_conf__mags_1_make_mag_folder_False(tmp_path):
+  kd = KnossosDataset()
+  with pytest.raises(AssertionError):
+    kd.initialize_without_conf(str(tmp_path), boundary=(7, 9, 19), scale=(1, 1, 1), experiment_name='test', mags=[1], make_mag_folders=False, verbose=True)

--- a/tests/test_knossos_utils.py
+++ b/tests/test_knossos_utils.py
@@ -4,7 +4,8 @@ import pytest
 import numpy as np
 
 @pytest.mark.parametrize("boundary", [np.array([7,9,10]), (7,9,10), [7, 9, 10]])
-def test_KnossosDataset_initialize_without_conf(tmp_path, boundary):
+@pytest.mark.parametrize("mags", [None, [1]])
+def test_KnossosDataset_initialize_without_conf(tmp_path, boundary, mags):
   kd = KnossosDataset()
-  kd.initialize_without_conf(str(tmp_path), boundary=boundary, scale=(1, 1, 1), experiment_name='test', mags=[1], verbose=True)
+  kd.initialize_without_conf(str(tmp_path), boundary=boundary, scale=(1, 1, 1), experiment_name='test', mags=mags, verbose=True)
 


### PR DESCRIPTION
Fixed initialization of `KnossosDataset` with method `initialize_without_conf`

Causing problems:

- glob wildcard `*` does not capture file separators.

Minor changes:
- documentation does not specify `boundary` instance type. Added casting to `numpy.Array`
- default parameter for `mags` causes error message. Added assertion to warn user.

Additional changes:
- Added github workflow file for pytest do proof proper function. 